### PR TITLE
Add eclipse-leshan-bot as bypass-actor about branch protection

### DIFF
--- a/otterdog/eclipse-leshan.jsonnet
+++ b/otterdog/eclipse-leshan.jsonnet
@@ -3,7 +3,7 @@ local orgs = import 'vendor/otterdog-defaults/otterdog-defaults.libsonnet';
 local defaultBranchesProtection(branches) = 
   orgs.newRepoRuleset("branch-protection") {
     bypass_actors+: [
-      "@eclipse-leshan/iot-leshan-project-leads"
+      "@eclipse-leshan/iot-leshan-project-leads", "@eclipse-leshan-bot"
     ],
     include_refs+: [std.format("refs/heads/%s", branch) for branch in branches],
     required_pull_request+: {


### PR DESCRIPTION
I try to do a release.
I guess I didn't do a release since we add otterdog to the project.

[Last release job](https://ci.eclipse.org/leshan/job/leshan-release/12) I run failed with : 
```
+ git push --set-upstream origin master
remote: error: GH013: Repository rule violations found for refs/heads/master.        
remote: Review all repository rules at https://github.com/eclipse-leshan/leshan/rules?ref=refs%2Fheads%2Fmaster        
remote: 
remote: - Changes must be made through a pull request.        
remote: 
remote: - Required status check "eclipsefdn/eca" is expected.        
remote: 
To github.com:eclipse-leshan/leshan.git
 ! [remote rejected]   master -> master (push declined due to repository rule violations)
error: failed to push some refs to 'github.com:eclipse-leshan/leshan.git'
```
See [console log](https://ci.eclipse.org/leshan/job/leshan-release/12/console) for more details.

I guess I need to add  eclipse-leshan-bot as bypass-actor about branch protection, right ? 

(I'm not 100% sure about the syntax and the [bot name](https://github.com/eclipse-leshan-bot))